### PR TITLE
Subdue backlinks, fix bugs in portal text sampling

### DIFF
--- a/src/references.ts
+++ b/src/references.ts
@@ -156,6 +156,8 @@ export function layoutBacklinks(
 
 	const lineBbox = getLeafLineBBox(leaf);
 
+	const BACKLINK_LEFT_MARGIN = 64;
+
 	// Create the initial backlink mark if necessary and position it in the correct vertical position
 	let referenceMarkers = backlinksToLeaf.map((backlink) => {
 		const { from } = backlink.referencedLocation;
@@ -180,7 +182,7 @@ export function layoutBacklinks(
 			const absoluteY = bbox.top - scrollerBbox.top + editorView.scrollDOM.scrollTop;
 			referenceMarker.setAttribute("top", absoluteY.toString());
 			referenceMarker.style.top = absoluteY + "px";
-			referenceMarker.style.left = lineBbox.width + 40 + "px";
+			referenceMarker.style.left = lineBbox.width + BACKLINK_LEFT_MARGIN + "px";
 		}
 
 		return referenceMarker;
@@ -220,7 +222,7 @@ export function layoutBacklinks(
 			lastYBottom = top + marker.getBoundingClientRect().height;
 			marker.setAttribute("top", top.toString());
 			marker.style.top = top + "px";
-			marker.style.left = lineBbox.width + 40 + "px";
+			marker.style.left = lineBbox.width + BACKLINK_LEFT_MARGIN + "px";
 		});
 }
 
@@ -414,39 +416,29 @@ export function createBacklinkData(
 				}
 			}
 
-			let portalText = line.replace(new RegExp(REFERENCE_REGEX, "g"), "↗");
-			let portalTextSlice = portalText.slice(0, PORTAL_TEXT_SLICE_SIZE);
+			const portalReferenceRepresentation = "↗";
+			let portalText = line.replace(new RegExp(REFERENCE_REGEX, "g"), portalReferenceRepresentation);
 
 			let portalTextIndex = line.indexOf(match[0]) - matchIndex;
 
-			// getting the portal text selection around the reference
-			portalTextSlice = "↗";
+			const PORTAL_CONTEXT_LIMIT = 120;
 
+			// getting the portal text selection around the reference
 			let startPortalText = portalText.substring(
-				Math.max(portalTextIndex - 25, 0),
+				Math.max(portalTextIndex - PORTAL_CONTEXT_LIMIT, 0),
 				portalTextIndex
 			);
 
-			if (
-				portalText.substring(Math.max(portalTextIndex - 25, 0), portalTextIndex)
-					.length > 0 &&
-				portalTextIndex - 25 > 0
-			)
-				startPortalText = "..." + startPortalText;
+			if (startPortalText.length > 0 && portalTextIndex - PORTAL_CONTEXT_LIMIT >= 0)
+				startPortalText = "…" + startPortalText;
 
 			let endPortalText = portalText.substring(
 				portalTextIndex + 1,
-				Math.max(portalTextIndex + 25, portalText.length)
+				Math.min(portalTextIndex + PORTAL_CONTEXT_LIMIT, portalText.length)
 			);
 
-			if (
-				portalText.substring(
-					portalTextIndex + 1,
-					Math.max(portalTextIndex + 25, portalText.length)
-				).length > 0 &&
-				portalTextIndex + 25 < portalText.length
-			)
-				endPortalText = endPortalText + "...";
+			if (endPortalText.length > 0 && portalTextIndex + PORTAL_CONTEXT_LIMIT < portalText.length)
+				endPortalText = endPortalText + "…";
 
 			backlinks.push({
 				referencedLocation,
@@ -455,7 +447,7 @@ export function createBacklinkData(
 				portalText:
 					encodeURIComponentString(startPortalText) +
 					":" +
-					portalTextSlice +
+					portalReferenceRepresentation +
 					":" +
 					encodeURIComponentString(endPortalText),
 			});

--- a/styles.css
+++ b/styles.css
@@ -66,18 +66,27 @@ If your plugin does not need CSS, delete this file.
 }
 
 .backlink-span {
-	background-color: color-mix(in srgb, var(--color-base-30) 50%, var(--color-base-40) 50%) ;
-	border-radius: 3px;
-	padding-left: 3px;
-	color: var(--text-normal);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: 4px;
+	padding: 4px 8px;
+	color: var(--text-muted);
+	line-height: var(--line-height-tight);
+	font-size: var(--font-small);
+	transform: translateY(calc(-1 * (4px + 1px))); /* undo padding and border */
+	max-width: 300px;
 }
 
 .backlink-span:hover {
-	background-color: hsl(calc(var(--accent-h) - 3), calc(var(--accent-s) * 1.02), calc(var(--accent-l) * 1.3));
+	background-color: var(--background-modifier-hover);
 }
 
 .backlink-span::after {
 	display:none !important
+}
+
+.backlink-span .text-accent {
+	color: var(--text-faint);
+	padding-right: 1px;
 }
 
 


### PR DESCRIPTION
I've done a pass on the backlink portals, subduing them to (what seems to me to be) a more appropriate level in the information hierarchy.

I also fixed several bugs in the code which extracts the surrounding text and truncates it if necessary. The predicate for prefix truncation had the wrong boundary condition, and the limit was not being correctly applied to suffixes.

Before:
<img width="2672" alt="Screenshot 2024-02-02 at 2 43 49 PM" src="https://github.com/Siunami/obsidian-reference-plugin/assets/2771/ba15a71b-9db2-4ddf-ad92-98aed4403728">


After:
<img width="2672" alt="Screenshot 2024-02-02 at 2 38 55 PM" src="https://github.com/Siunami/obsidian-reference-plugin/assets/2771/9fd9f79f-0746-441a-9534-1fda1d4be534">
