### PR TITLE
Use theme highlight colors for reference highlights

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -48,17 +48,11 @@ If your plugin does not need CSS, delete this file.
 	color: var(--text-accent);
 }
 
-.reference-span-selected {
-	color: #1e1e1e;
-	background-color: hsl(calc(var(--accent-h) - 3), calc(var(--accent-s) * 1.02), calc(var(--accent-l) * 1.3));
-}
-
-.reference-span-selected:hover {
-	background-color: hsl(calc(var(--accent-h) - 3), calc(var(--accent-s) * 1.02), calc(var(--accent-l) * 1.3));
+.reference-span-selected, .reference-data-span-selected::after {
+	border-bottom: 1px solid var(--text-normal);
 }
 
 .reference-data-span-selected::after {
-	background-color: hsl(calc(var(--accent-h) - 3), calc(var(--accent-s) * 1.02), calc(var(--accent-l) * 1.3));
 }
 
 .backlink-hide-after::after {
@@ -108,14 +102,13 @@ If your plugin does not need CSS, delete this file.
 }
 
 .highlight {
-	background-color: hsl(calc(var(--accent-h) - 3), calc(var(--accent-s) * 1.02), calc(var(--accent-l) * 1.3));
-	color: black;
+	background-color: var(--text-highlight-bg);
+	border-bottom: 1px solid var(--text-normal);
 	z-index: 100;
 }
 
 .default-highlight {
-	background-color: hsl(calc(var(--accent-h) - 3), calc(var(--accent-s) * 1.02), calc(var(--accent-l) * 1.43));
-	color: black;
+	background-color: var(--text-highlight-bg);
 }
 
 

--- a/styles.css
+++ b/styles.css
@@ -52,9 +52,6 @@ If your plugin does not need CSS, delete this file.
 	border-bottom: 1px solid var(--text-normal);
 }
 
-.reference-data-span-selected::after {
-}
-
 .backlink-hide-after::after {
 	display:none;
 }


### PR DESCRIPTION
⚠️ This is not ready to merge because there appears to be a bug with the creation/maintenance of highlight spans, revealed by the fact that this change uses a highlight span with a translucent background. If you open a source note and a referencing note side by side, then command-hover a reference several times, you'll see the highlight get brighter and brighter as more spans get stacked on top of each other without being removed.

It would probably be good to give some systematic thought to the semantic meaning of various colors in this plugin, but until that time, this will at least ensure that reference highlight colors used are compatible with a user's theme.

Before:
<img width="1840" alt="Screenshot 2024-02-09 at 3 42 26 PM" src="https://github.com/Siunami/obsidian-reference-plugin/assets/2771/02e81157-b509-4947-a89e-bff584e3b142">

After:
<img width="1840" alt="Screenshot 2024-02-09 at 3 41 59 PM" src="https://github.com/Siunami/obsidian-reference-plugin/assets/2771/1f499a6a-faef-4e51-9408-538303ec3468">
